### PR TITLE
Add Auth page and route; replace header login button with link

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Header from "./components/Header";
 import Body from "./components/Body";
 import About from "./components/About";
 import Contact from "./components/Contact";
+import Auth from "./components/Auth";
 import Error from "./components/Error";
 import { createBrowserRouter, RouterProvider, Outlet } from "react-router-dom";
 import RestaurantMenu from "./components/RestaurantMenu";
@@ -54,6 +55,10 @@ let appRouter = createBrowserRouter([
       {
         path: "/contact",
         element: <Contact />,
+      },
+      {
+        path: "/auth",
+        element: <Auth />,
       },
       {
         path: "/grocery",

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+
+const inputBaseClass =
+  "w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-600";
+
+const LoginForm = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Password</label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Enter your password"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full rounded-lg bg-purple-700 px-4 py-2 font-medium text-white shadow hover:bg-purple-800 transition-colors"
+      >
+        Login
+      </button>
+    </form>
+  );
+};
+
+const SignupForm = () => {
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  return (
+    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Full Name</label>
+        <input
+          type="text"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          placeholder="Your name"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Phone Number</label>
+        <input
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          placeholder="9876543210"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Password</label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Create a password"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Confirm Password</label>
+        <input
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          placeholder="Re-enter password"
+          className={inputBaseClass}
+          required
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full rounded-lg bg-gradient-to-r from-purple-600 to-pink-500 px-4 py-2 font-medium text-white shadow hover:opacity-90 transition-colors"
+      >
+        Create Account
+      </button>
+    </form>
+  );
+};
+
+const Auth = () => {
+  const [activeTab, setActiveTab] = useState("login");
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-50 to-pink-50 px-6 py-10">
+      <div className="w-full max-w-md rounded-2xl border border-gray-100 bg-white p-8 shadow-xl">
+        <h1 className="mb-2 text-center text-3xl font-bold text-gray-900">Welcome to HungerHop</h1>
+        <p className="mb-6 text-center text-sm text-gray-500">
+          {activeTab === "login"
+            ? "Login to continue ordering your favorite meals."
+            : "Create a new account to start exploring restaurants."}
+        </p>
+
+        <div className="mb-6 grid grid-cols-2 rounded-lg bg-gray-100 p-1">
+          <button
+            className={`rounded-md py-2 text-sm font-medium transition-colors ${
+              activeTab === "login" ? "bg-white text-purple-700 shadow" : "text-gray-600"
+            }`}
+            onClick={() => setActiveTab("login")}
+          >
+            Login
+          </button>
+          <button
+            className={`rounded-md py-2 text-sm font-medium transition-colors ${
+              activeTab === "signup" ? "bg-white text-purple-700 shadow" : "text-gray-600"
+            }`}
+            onClick={() => setActiveTab("signup")}
+          >
+            Signup
+          </button>
+        </div>
+
+        {activeTab === "login" ? <LoginForm /> : <SignupForm />}
+      </div>
+    </div>
+  );
+};
+
+export default Auth;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useContext } from "react";
 import { LOGO_URL } from "../utils/constants";
 import { Link } from "react-router-dom";
 import useOnlineStatus from "../utils/useOnlineStatus";
@@ -6,7 +6,6 @@ import UserContext from "../utils/UserContext";
 import { useSelector } from "react-redux";
 
 export default function Header() {
-  const [btnName, setBtnName] = useState("Login");
   const onlineStatus = useOnlineStatus();
 
   const { loggedInUser } = useContext(UserContext);
@@ -75,16 +74,13 @@ export default function Header() {
               <span className="absolute left-0 -bottom-1 w-0 h-0.5 bg-purple-700 transition-all group-hover:w-full"></span>
             </li>
 
-            {/* Login/Logout Button */}
             <li>
-              <button
-                onClick={() =>
-                  setBtnName(btnName === "Login" ? "Logout" : "Login")
-                }
-                className="ml-4 px-4 py-2 rounded-lg bg-purple-700 text-white shadow-md hover:bg-purple-800 transition-colors transform hover:-translate-y-0.5"
+              <Link
+                to="/auth"
+                className="ml-4 inline-block rounded-lg bg-purple-700 px-4 py-2 text-white shadow-md transition-colors hover:bg-purple-800"
               >
-                {btnName}
-              </button>
+                Login / Signup
+              </Link>
             </li>
             <li className="relative group cursor-pointer hover:text-purple-700">
               {loggedInUser}


### PR DESCRIPTION
### Motivation

- Add a dedicated authentication UI for login and signup to support user onboarding and sign-in flows. 
- Expose the auth UI via routing so users can navigate to a single `/auth` page. 
- Simplify header behavior by removing local login button state and routing users to the new auth page.

### Description

- Added a new `Auth` component at `src/components/Auth.jsx` that implements `LoginForm`, `SignupForm`, and a tab switcher for Login/Signup with responsive Tailwind-based styling. 
- Imported the `Auth` component in `src/App.jsx` and registered a new route `{ path: "/auth", element: <Auth /> }` in the router. 
- Updated `src/components/Header.jsx` to remove the local `useState` login button and replace it with a `Link` to `/auth`, and kept cart item count display via the Redux selector.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b571b5d88321910aa66800253160)